### PR TITLE
fix: Example Ingress configuration for the rust hello-world application

### DIFF
--- a/deploy/k8s/kustomize/deploy/dev/apps/wadm.yaml
+++ b/deploy/k8s/kustomize/deploy/dev/apps/wadm.yaml
@@ -45,4 +45,4 @@ spec:
             source_config:
               - name: default-http
                 properties:
-                  address: 127.0.0.1:8080
+                  address: 0.0.0.0:8080

--- a/deploy/k8s/kustomize/deploy/dev/ingress.yaml
+++ b/deploy/k8s/kustomize/deploy/dev/ingress.yaml
@@ -7,8 +7,8 @@ spec:
   rules:
   - http:
       paths:
-      - path: /
-        pathType: Prefix
+      - path: /rust
+        pathType: Exact
         backend:
           service:
             name: rust-hello-world


### PR DESCRIPTION
## Feature or Problem

This makes the ingress work out of the box.

The `pathType` change from `Prefix` to `Exact` isn't strictly necessary, but I think it's useful in this case since it's only serving a single endpoint anyway.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
